### PR TITLE
Fix deprecation warning: Use RbConfig instead of Config

### DIFF
--- a/lib/binding_of_caller.rb
+++ b/lib/binding_of_caller.rb
@@ -1,4 +1,4 @@
-dlext = Config::CONFIG['DLEXT']
+dlext = RbConfig::CONFIG['DLEXT']
 direc = File.dirname(__FILE__)
 
 if RUBY_ENGINE && RUBY_ENGINE == "ruby"


### PR DESCRIPTION
Got a deprecation warning in 1.9.3-p125, this fixes it.
