### PR TITLE
Avoid loops and calls of expensive methods

### DIFF
--- a/lib/binding_of_caller/mri2.rb
+++ b/lib/binding_of_caller/mri2.rb
@@ -5,61 +5,58 @@ module BindingOfCaller
     # Retrieve the binding of the nth caller of the current frame.
     # @return [Binding]
     def of_caller(n)
-      c = callers.drop(1)
-      if n > (c.size - 1)
-        raise "No such frame, gone beyond end of stack!"
-      else
-        c[n]
-      end
+      RubyVM::DebugInspector.open { |i| setup_binding_from_location(i, n+2) }
+    rescue
+      raise "No such frame, gone beyond end of stack!"
     end
 
     # Return bindings for all caller frames.
     # @return [Array<Binding>]
     def callers
-      ary = []
-    
       RubyVM::DebugInspector.open do |i|
-        n = 0
-        loop do
-          begin
-            b = i.frame_binding(n) 
-          rescue ArgumentError
-            break
-          end
-
-          if b
-            b.instance_variable_set(:@iseq, i.frame_iseq(n))
-            ary << b
-          end
-          
-          n += 1
+        (2..(i.backtrace_locations.count-2)).map do |n|
+          setup_binding_from_location(i, n)
         end
       end
-      
-      ary.drop(1)
     end
 
     # Number of parent frames available at the point of call.
     # @return [Fixnum]
     def frame_count
-      callers.size - 1
+      RubyVM::DebugInspector.open(&:backtrace_locations).count - 3
     end
 
     # The type of the frame.
     # @return [Symbol]
     def frame_type
-      return nil if !@iseq
-      
-      # apparently the 9th element of the iseq array holds the frame type
-      # ...not sure how reliable this is.
-      @frame_type ||= @iseq.to_a[9]
+      if not @iseq.nil?
+        # apparently the 9th element of the iseq array holds the frame type
+        # ...not sure how reliable this is.
+        @frame_type ||= @iseq.to_a[9]
+      end
     end
 
     # The description of the frame.
     # @return [String]
     def frame_description
-      return nil if !@iseq
-      @frame_description ||= @iseq.label
+      if not @iseq.nil?
+        @frame_description ||= @iseq.label
+      end
+    end
+
+    protected
+
+    def setup_binding_from_location(inspector, frame_number)
+      binding = inspector.frame_binding(frame_number)
+
+      if binding.nil?
+        binding = setup_binding_from_location(inspector, frame_number + 1)
+      end
+
+      binding.instance_variable_set(:@iseq,
+                                    inspector.frame_iseq(frame_number))
+
+      binding
     end
   end
 end

--- a/lib/binding_of_caller/rubinius.rb
+++ b/lib/binding_of_caller/rubinius.rb
@@ -6,7 +6,9 @@ module BindingOfCaller
     def of_caller(n)
       location = Rubinius::VM.backtrace(1 + n, true).first
 
-      raise RuntimeError, "Invalid frame, gone beyond end of stack!" if location.nil?
+      if location.nil?
+        raise RuntimeError, "Invalid frame, gone beyond end of stack!"
+      end
 
       setup_binding_from_location(location)
     end
@@ -20,8 +22,7 @@ module BindingOfCaller
     # Return bindings for all caller frames.
     # @return [Array<Binding>]
     def callers
-      Rubinius::VM.backtrace(1, true).map &(method(:setup_binding_from_location).
-                                            to_proc)
+      Rubinius::VM.backtrace(1, true).map{|l| setup_binding_from_location(l)}
     end
 
     # Number of parent frames available at the point of call.


### PR DESCRIPTION
## MRI2.0
- #frame_count counts the number of itens in
  `RubyVM::DebugInspector#backtrace_locations` instead of `callers.count`
- Refactor condition of `@iseq.nil?` on #frame_type and #frame_description
- Use a (1..n) mapping of bindings on #callers instead of looping
- Share code that setup the binding from a location for #callers
  and #of_caller

```
    ❯ gc master
    Switched to branch 'master'
    ❯ ruby examples/benchmarks.rb
                     user     system      total        real
    #of_caller  16.760000   0.000000  16.760000 ( 16.771434)
    #frame_count  7.880000   0.000000   7.880000 (  7.893651)
    #callers     8.040000   0.000000   8.040000 (  8.043962)
    #frame_description  8.860000   0.000000   8.860000 (  8.866258)
    #frame_type 12.560000   0.000000  12.560000 ( 12.575982)
    ❯ gc avoid_loops
    Switched to branch 'avoid_loops'
    ❯ ruby examples/benchmarks.rb
                     user     system      total        real
    #of_caller   6.330000   0.010000   6.340000 (  6.346398)
    #frame_count  3.010000   0.000000   3.010000 (  3.011249)
    #callers     6.280000   0.000000   6.280000 (  6.288488)
    #frame_description  3.410000   0.000000   3.410000 (  3.413291)
    #frame_type  3.450000   0.000000   3.450000 (  3.448674)
```
## RBX
- #frame_count counts the number of itens in `Rubinius::VM.backtrace(1)`
  instead of `callers.count`
- Use a (1..n) mapping of bindings on #callers instead of looping
- Share code that setup the binding from a location for #callers
  and #of_caller
