### PR TITLE
Add MRI 2.1 as working Ruby implementation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - rbx-19mode
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ binding_of_caller
 
 (C) John Mair (banisterfiend) 2012
 
-_Retrieve the binding of a method's caller in MRI 1.9.2+, MRI 2.0 and RBX (Rubinius)_
+_Retrieve the binding of a method's caller in MRI 1.9.2+, MRI 2.0, MRI 2.1 and RBX (Rubinius)_
 
 The `binding_of_caller` gem provides the `Binding#of_caller` method.
 
@@ -15,7 +15,7 @@ call stack, not limited to just the immediate caller.
 
 **Recommended for use only in debugging situations. Do not use this in production apps.**
 
-**Only works in MRI Ruby 1.9.2, 1.9.3, 2.0 and RBX (Rubinius)**
+**Only works in MRI Ruby 1.9.2, 1.9.3, 2.0, 2.1 and RBX (Rubinius)**
 
 * Install the [gem](https://rubygems.org/gems/binding_of_caller): `gem install binding_of_caller`
 * See the [source code](http://github.com/banister/binding_of_caller)
@@ -52,7 +52,7 @@ This project is a spinoff from the [Pry REPL project.](http://pry.github.com)
 Features and limitations
 -------------------------
 
-* Only works with MRI 1.9.2, 1.9.3, 2.0 and RBX (Rubinius)
+* Only works with MRI 1.9.2, 1.9.3, 2.0, 2.1 and RBX (Rubinius)
 * Does not work in 1.8.7, but there is a well known (continuation-based) hack to get a `Binding#of_caller` there.
 * There is experimental support for jruby, but it only works in interpreted
 mode (i.e. use the option `-Djruby.compile.mode=OFF` or append


### PR DESCRIPTION
Pasising Travis run for binding_of_caller: https://travis-ci.org/DevL/binding_of_caller
Passing Travis run for [bless](https://github.com/DevL/bless) (a gem of mine using binding_of_caller): https://travis-ci.org/DevL/bless
