### PR TITLE
Add support for frame_type and frame_description in JRuby

### DIFF
--- a/lib/binding_of_caller/jruby_interpreted.rb
+++ b/lib/binding_of_caller/jruby_interpreted.rb
@@ -1,11 +1,100 @@
+module BindingOfCaller
+  class JRubyBindingHolder
+    java_import org.jruby.RubyBinding
+
+    def initialize(binding)
+      @binding = binding
+    end
+
+    def eval(code, file = nil, line = nil)
+      b = JRuby.dereference(RubyBinding.new(JRuby.runtime, Binding, @binding))
+      if (file == nil)
+        Kernel.eval code, b
+      else
+        Kernel.eval code, b, file, line
+      end
+    end
+
+    def frame_type
+      case
+        when block?
+          :block
+        when eval?
+          :eval
+        when top?
+          :top
+        else
+          :method
+      end
+    end
+
+    def frame_description
+      "#{block_desc}#{method_desc}"
+    end
+
+    private
+
+    def block?
+      @binding.getDynamicScope().getStaticScope().isBlockScope()
+    end
+
+    def eval?
+      @binding.getFrame().getKlazz().nil? && @binding.getLine() != 0
+    end
+
+    def top?
+      @binding.getFrame().getKlazz().nil? && @binding.getLine() == 0
+    end
+
+    def block_desc
+      if frame_type == :block
+        "block in "
+      end
+    end
+
+    def method_desc
+      @binding.getFrame().getName() || "<main>"
+    end
+  end
+
+  module BindingExtensions
+    def of_caller(index = 1)
+      index += 1 # always omit this frame
+      JRuby.runtime.current_context.binding_of_caller(index)
+    end
+
+    def callers
+      ary = []
+      n = 2
+      while binding = of_caller(n)
+        ary << binding
+        n += 1
+      end
+      ary
+    end
+
+    def frame_count
+      callers.count - 1
+    end
+
+    def frame_type
+      nil
+    end
+
+    def frame_description
+      nil
+    end
+  end
+end
+
+
 class org::jruby::runtime::ThreadContext
   java_import org.jruby.runtime.Binding
-  java_import org.jruby.RubyBinding
   java_import org.jruby.RubyInstanceConfig::CompileMode
 
   field_accessor :frameStack, :frameIndex,
-    :scopeStack, :scopeIndex,
-    :backtrace, :backtraceIndex
+                 :scopeStack, :scopeIndex,
+                 :backtrace, :backtraceIndex
 
   def binding_of_caller(index)
     unless JRuby.runtime.instance_config.compile_mode == CompileMode::OFF
@@ -14,7 +103,7 @@ class org::jruby::runtime::ThreadContext
 
     index += 1 # always omit this frame
 
-    raise RuntimeError, "Invalid frame, gone beyond end of stack!" if index > frameIndex
+    return nil if index > frameIndex
 
     frame = frameStack[frameIndex - index]
 
@@ -25,40 +114,10 @@ class org::jruby::runtime::ThreadContext
 
     binding = Binding.new(frame, scope.static_scope.module, scope, element.clone)
 
-    JRuby.dereference(RubyBinding.new(JRuby.runtime, Binding, binding))
-  end
-end
-
-module BindingOfCaller
-  module BindingExtensions
-    def of_caller(index = 1)
-      index += 1 # always omit this frame
-      JRuby.runtime.current_context.binding_of_caller(index)
-    end
-
-    def callers
-      ary = []
-      n = 2
-      loop do
-        ary << of_caller(n) rescue break
-        n += 1
-      end
-      ary
-    end
-
-    def frame_count
-      callers.count - 1
-    end
+    BindingOfCaller::JRubyBindingHolder.new(binding)
   end
 end
 
 class ::Binding
   include BindingOfCaller::BindingExtensions
-  extend BindingOfCaller::BindingExtensions
-end
-
-class Java::OrgJrubyRuntime::Binding
-  def eval(code)
-    Kernel.eval code, self
-  end
 end


### PR DESCRIPTION
This commit refactors the experimental JRuby support such that
we can return roughly the same values for 'frame_type' and
'frame_description' in JRuby that we see in MRI.

This still has some limitations due to the following bugs:

https://github.com/pry/pry/issues/1205
https://github.com/pry/pry-stack_explorer/issues/20

But should be an improvement over the previous implementation.