### PR TITLE
Don't pollute toplevel with mri_2? method

### DIFF
--- a/lib/binding_of_caller.rb
+++ b/lib/binding_of_caller.rb
@@ -1,11 +1,9 @@
 dlext = RbConfig::CONFIG['DLEXT']
 
-def mri_2?
-  defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" &&
+mri_2 = defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" &&
     RUBY_VERSION =~ /^2/
-end
 
-if mri_2?
+if mri_2
   require 'binding_of_caller/mri2'
 elsif defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby"
   require "binding_of_caller.#{dlext}"


### PR DESCRIPTION
Since `mri_2?` method for this gem internal use is defined on toplevel, this method can actually be called from anywhere in our apps.

e.g.
```
% rails r "p mri_2?"
0
```

This method is actually not used anywhere else even in this gem, so this can just be a variable instead of method.