### PR TITLE
Ruby 2.5.0 (mri2) 'callers' method fix with better_errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.2.6
   - 2.3.0
   - 2.4.0
+  - 2.5.0
 
 notifications:
   irc: "irc.freenode.org#pry"

--- a/lib/binding_of_caller/mri2.rb
+++ b/lib/binding_of_caller/mri2.rb
@@ -17,25 +17,19 @@ module BindingOfCaller
     # @return [Array<Binding>]
     def callers
       ary = []
-    
-      RubyVM::DebugInspector.open do |i|
-        n = 0
-        loop do
-          begin
-            b = i.frame_binding(n) 
-          rescue ArgumentError
-            break
-          end
 
+      RubyVM::DebugInspector.open do |dc|
+        locs = dc.backtrace_locations
+
+        locs.size.times do |i|
+          b = dc.frame_binding(i)
           if b
-            b.instance_variable_set(:@iseq, i.frame_iseq(n))
+            b.instance_variable_set(:@iseq, dc.frame_iseq(i))
             ary << b
           end
-          
-          n += 1
         end
       end
-      
+
       ary.drop(1)
     end
 


### PR DESCRIPTION
This is a ruby 2.5.0 (mri2) fix for charliesome/better_errors#411, where `callers` method returned an empty array in better_errors context.