### PR TITLE
Add licensing information to gemspec.

### DIFF
--- a/binding_of_caller.gemspec
+++ b/binding_of_caller.gemspec
@@ -5,6 +5,7 @@
 Gem::Specification.new do |s|
   s.name = "binding_of_caller".freeze
   s.version = "0.8.0"
+  s.licenses = ["MIT"]
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]


### PR DESCRIPTION
This should make it easier for automated tools to find out what license is used.