### PR TITLE
docs: fix simple typo, ambiguos -> ambiguous

### DIFF
--- a/ext/binding_of_caller/ruby_headers/192/vm_core.h
+++ b/ext/binding_of_caller/ruby_headers/192/vm_core.h
@@ -205,7 +205,7 @@ struct rb_iseq_struct {
      *  arg_block      = M+N + 1 + O + 1 // -1 if no block arg
      *  arg_simple     = 0 if not simple arguments.
      *                 = 1 if no opt, rest, post, block.
-     *                 = 2 if ambiguos block parameter ({|a|}).
+     *                 = 2 if ambiguous block parameter ({|a|}).
      *  arg_size       = argument size.
      */
 

--- a/ext/binding_of_caller/ruby_headers/193/vm_core.h
+++ b/ext/binding_of_caller/ruby_headers/193/vm_core.h
@@ -207,7 +207,7 @@ struct rb_iseq_struct {
      *  arg_block      = M+N + 1 + O + 1 // -1 if no block arg
      *  arg_simple     = 0 if not simple arguments.
      *                 = 1 if no opt, rest, post, block.
-     *                 = 2 if ambiguos block parameter ({|a|}).
+     *                 = 2 if ambiguous block parameter ({|a|}).
      *  arg_size       = argument size.
      */
 


### PR DESCRIPTION
There is a small typo in ext/binding_of_caller/ruby_headers/192/vm_core.h, ext/binding_of_caller/ruby_headers/193/vm_core.h.

Should read `ambiguous` rather than `ambiguos`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md