### PR TITLE
Ruby 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.3.0
   - 2.4.0
   - 2.5.0
+  - 3.0.0
 
 notifications:
   irc: "irc.freenode.org#pry"

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'debug_inspector', git: 'https://github.com/banister/debug_inspector.git'

--- a/Rakefile
+++ b/Rakefile
@@ -13,9 +13,16 @@ CLEAN.include("ext/**/*.#{dlext}", "ext/**/*.log", "ext/**/*.o",
               "ext/**/*~", "ext/**/*#*", "ext/**/*.obj", "**/*#*", "**/*#*.*",
               "ext/**/*.def", "ext/**/*.pdb", "**/*_flymake*.*", "**/*_flymake", "**/*.rbc")
 
+def mri?
+  defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby"
+end
+
 def mri_2?
-  defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" &&
-    RUBY_VERSION =~ /^2/
+  mri? && RUBY_VERSION =~ /^2/
+end
+
+def mri_3?
+  mri? && RUBY_VERSION =~ /^3/
 end
 
 def apply_spec_defaults(s)
@@ -89,7 +96,7 @@ end
 
 desc "build the binaries"
 task :compile => :cleanup do
-  if !mri_2?
+  if !mri_2? && !mri_3?
     chdir "./ext/binding_of_caller/" do
       sh "ruby extconf.rb"
       sh "make"
@@ -100,7 +107,7 @@ end
 
 desc 'cleanup the extensions'
 task :cleanup do
-  if !mri_2?
+  if !mri_2? && !mri_3?
     sh 'rm -rf lib/binding_of_caller.so'
     chdir "./ext/binding_of_caller/" do
       sh 'make clean'

--- a/lib/binding_of_caller.rb
+++ b/lib/binding_of_caller.rb
@@ -1,9 +1,12 @@
 dlext = RbConfig::CONFIG['DLEXT']
 
-mri_2 = defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby" &&
-    RUBY_VERSION =~ /^2/
+mri = defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby"
 
-if mri_2
+mri_2 = mri && RUBY_VERSION =~ /^2/
+
+mri_3 = mri && RUBY_VERSION =~ /^3/
+
+if mri_2 || mri_3
   require 'binding_of_caller/mri2'
 elsif defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby"
   require "binding_of_caller.#{dlext}"


### PR DESCRIPTION
In order for this to work, we need a new version of https://github.com/banister/debug_inspector from HEAD (see https://github.com/banister/debug_inspector/issues/27).

But other than that and an update to the gemspec of this gem, this should be the changes necessary to work with Ruby 3.

Tests are passing locally, as it's using `HEAD` of `debug_inspector` through `Gemfile`.

To use `binding_of_caller` in any app with Ruby 3 you should be able to use this in your Gemfile:

```ruby
gem 'debug_inspector', git: 'https://github.com/banister/debug_inspector.git'
gem 'binding_of_caller', git: 'https://github.com/walski/binding_of_caller.git', branch: 'ruby-3'
```