### PR TITLE
Fix - Deprecation Warning on DebugInspector

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
+          - "3.2"
         exclude:
           # 2.2 segfaults on recent Ubuntu: https://github.com/ruby/setup-ruby/issues/496
           - { ruby: "2.2" }

--- a/binding_of_caller.gemspec
+++ b/binding_of_caller.gemspec
@@ -31,5 +31,5 @@ TXT
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "debug_inspector", ">= 0.0.1"
+  spec.add_dependency "debug_inspector", ">= 1.2.0"
 end

--- a/lib/binding_of_caller/mri.rb
+++ b/lib/binding_of_caller/mri.rb
@@ -18,7 +18,7 @@ module BindingOfCaller
     def callers
       ary = []
 
-      RubyVM::DebugInspector.open do |dc|
+      DebugInspector.open do |dc|
         locs = dc.backtrace_locations
 
         locs.size.times do |i|
@@ -43,7 +43,7 @@ module BindingOfCaller
     # @return [Symbol]
     def frame_type
       return nil if !@iseq
-      
+
       # apparently the 9th element of the iseq array holds the frame type
       # ...not sure how reliable this is.
       @frame_type ||= @iseq.to_a[9]

--- a/lib/binding_of_caller/version.rb
+++ b/lib/binding_of_caller/version.rb
@@ -1,3 +1,3 @@
 module BindingOfCaller
-  VERSION = "1.0.1"
+  VERSION = "1.0.0"
 end

--- a/lib/binding_of_caller/version.rb
+++ b/lib/binding_of_caller/version.rb
@@ -1,3 +1,3 @@
 module BindingOfCaller
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Addressing deprecation warnings from changes to `debug_inspector` gem dependency.

````ruby
.rbenv/versions/3.0.5/lib/ruby/gems/3.0.0/gems/binding_of_caller-1.0.0/lib/binding_of_caller/mri.rb:21: warning: constant RubyVM::DebugInspector is deprecated
````