### PR TITLE
Fix typo, descripton -> description

### DIFF
--- a/spec/binding_of_caller_spec.rb
+++ b/spec/binding_of_caller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe BindingOfCaller do
     end
   end
 
-  describe "#frame_descripton" do
+  describe "#frame_description" do
     it 'can be called on ordinary binding without raising' do
       expect { binding.frame_description }.not_to raise_error
     end


### PR DESCRIPTION
Found via `typos --format brief`