### PR TITLE
Excluding ruby 2.2 from tests due to segfault on Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+        exclude:
+          # 2.2 segfaults on recent Ubuntu: https://github.com/ruby/setup-ruby/issues/496
+          - { ruby: "2.2", os: "ubuntu-latest" }
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           - "3.0"
         exclude:
           # 2.2 segfaults on recent Ubuntu: https://github.com/ruby/setup-ruby/issues/496
-          - { ruby: "2.2", os: "ubuntu-latest" }
+          - { ruby: "2.2" }
 
     steps:
 


### PR DESCRIPTION
Ruby 2.2 won't work out of the box via setup-ruby due to segfault on latest Ubuntu.