### PR TITLE
Support Ruby 4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "4.0"
         exclude:
           # 2.2 segfaults on recent Ubuntu: https://github.com/ruby/setup-ruby/issues/496
           - { ruby: "2.2" }
@@ -57,6 +58,7 @@ jobs:
         ruby:
           - "2"
           - "3.0"
+          - "4.0"
           - "jruby"
           - "truffleruby"
         exclude:

--- a/lib/binding_of_caller.rb
+++ b/lib/binding_of_caller.rb
@@ -1,7 +1,7 @@
 require "binding_of_caller/version"
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby"
-  if RUBY_VERSION =~ /^[23]/
+  if RUBY_VERSION =~ /^[234]/
     require 'binding_of_caller/mri'
   else
     puts "This version of binding_of_caller doesn't support this version of Ruby"


### PR DESCRIPTION
The next version of Ruby looks to be Ruby 4.0 (https://github.com/ruby/ruby/commit/6d81969b475262aba251e99b518181bdf7c5a523).

I only found this out because one of my CI jobs that runs against Ruby HEAD started failing; it turns out that `rspec-parameterized-table_syntax` depends on `binding_of_caller`, which raises on Ruby 4. There doesn't appear to be any substantive change to adapt to.

Before this PR:

```
kivikakk@rebane ~/g/binding_of_caller ((no description set) y 1)> ~/g/ruby/out/bin/ruby -v
ruby 4.0.0dev (2025-11-10T03:04:49Z master cb50ed2cc2) +PRISM [arm64-darwin25]
kivikakk@rebane ~/g/binding_of_caller ((no description set) y 1)> ~/g/ruby/out/bin/bundle exec rspec
This version of binding_of_caller doesn't support this version of Ruby
Testing binding_of_caller version 1.0.1...
Ruby version: 4.0.0
FFFFFFFFFFFFFFF

Failures:

  1) BindingOfCaller#of_caller fetches the immediate caller's binding when 0 is passed
     Failure/Error: binding.of_caller(0).eval('var')

     NoMethodError:
       undefined method 'of_caller' for an instance of Binding
     # ./spec/binding_of_caller_spec.rb:12:in 'a'
     # ./spec/binding_of_caller_spec.rb:15:in 'block (3 levels) in <top (required)>'

[ ... etc. ... ]

Finished in 0.00658 seconds (files took 0.0367 seconds to load)
15 examples, 15 failures

Failed examples:

rspec ./spec/binding_of_caller_spec.rb:8 # BindingOfCaller#of_caller fetches the immediate caller's binding when 0 is passed
rspec ./spec/binding_of_caller_spec.rb:18 # BindingOfCaller#of_caller fetches the parent of caller's binding when 1 is passed
rspec ./spec/binding_of_caller_spec.rb:32 # BindingOfCaller#of_caller modifies locals in the parent of caller's binding
rspec ./spec/binding_of_caller_spec.rb:47 # BindingOfCaller#of_caller raises an exception when retrieving an out-of-band binding
rspec ./spec/binding_of_caller_spec.rb:62 # BindingOfCaller#callers returns the first non-internal binding when using callers.first
rspec ./spec/binding_of_caller_spec.rb:75 # BindingOfCaller#frame_count equals the binding callers.count
rspec ./spec/binding_of_caller_spec.rb:81 # BindingOfCaller#frame_description can be called on ordinary binding without raising
rspec ./spec/binding_of_caller_spec.rb:88 # BindingOfCaller#frame_description when inside a block describes a block frame
rspec ./spec/binding_of_caller_spec.rb:100 # BindingOfCaller#frame_description when inside an instance method describes a method frame with the method name
rspec ./spec/binding_of_caller_spec.rb:114 # BindingOfCaller#frame_description when inside a class definition describes a class frame
rspec ./spec/binding_of_caller_spec.rb:122 # BindingOfCaller#frame_type can be called on ordinary binding without raising
rspec ./spec/binding_of_caller_spec.rb:135 # BindingOfCaller#frame_type when inside a class definition returns :class
rspec ./spec/binding_of_caller_spec.rb:143 # BindingOfCaller#frame_type when evaluated returns :eval
rspec ./spec/binding_of_caller_spec.rb:151 # BindingOfCaller#frame_type when inside a block returns :block
rspec ./spec/binding_of_caller_spec.rb:163 # BindingOfCaller#frame_type when inside an instance method returns :method

kivikakk@rebane ~/g/binding_of_caller ((no description set) y 1) [1]>
```

After:

```
kivikakk@rebane ~/g/binding_of_caller ((no description set) r f)> ~/g/ruby/out/bin/ruby -v
ruby 4.0.0dev (2025-11-10T03:04:49Z master cb50ed2cc2) +PRISM [arm64-darwin25]
kivikakk@rebane ~/g/binding_of_caller ((no description set) r f)> ~/g/ruby/out/bin/bundle exec rspec
Testing binding_of_caller version 1.0.1...
Ruby version: 4.0.0
...............

Finished in 0.00489 seconds (files took 0.03735 seconds to load)
15 examples, 0 failures

kivikakk@rebane ~/g/binding_of_caller ((no description set) r f)>
```